### PR TITLE
chore: use the same version constraint in both test infra and release.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,11 +111,5 @@
 		"typescript": "^4.6.2",
 		"vsce": "^2.9.1",
 		"semver": "^7.3.7"
-	},
-	"__metadata": {
-		"id": "2acd93e8-6abe-4962-a7dc-795831b3f850",
-		"publisherDisplayName": "Mineiros",
-		"publisherId": "06229838-2113-4024-a01d-88c30a93ef73",
-		"isPreReleaseVersion": false
 	}
 }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 	"devDependencies": {
 		"@types/mocha": "^9.1.0",
 		"@types/node": "^14.17.0",
-		"@types/vscode": "^1.63.0",
+		"@types/vscode": "^1.52.0",
 		"@typescript-eslint/eslint-plugin": "^5.18.0",
 		"@typescript-eslint/parser": "^5.18.0",
 		"@vscode/test-electron": "^2.1.2",
@@ -111,5 +111,11 @@
 		"typescript": "^4.6.2",
 		"vsce": "^2.9.1",
 		"semver": "^7.3.7"
+	},
+	"__metadata": {
+		"id": "2acd93e8-6abe-4962-a7dc-795831b3f850",
+		"publisherDisplayName": "Mineiros",
+		"publisherId": "06229838-2113-4024-a01d-88c30a93ef73",
+		"isPreReleaseVersion": false
 	}
 }


### PR DESCRIPTION
The `vsce` tool requires the `devDependencies` to have the same vscode
engine version constraint as the released code but the
`devDependencies` here is only used to bootstrap the tests.. but
it does seem that we have any other way around this limitation.

As npm fetches the latest package that satisfies the condition, then
this doesn't change anything important, only that we cannot enforce
a newer vscode library in the tests.