### PR TITLE
fix: Terramate depends on go >= 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.19"
       - uses: actions/setup-node@v2
         with:
           node-version: ^18
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.19"
       - uses: actions/setup-node@v2
         with:
           node-version: ^18


### PR DESCRIPTION
Go is only used here to install the `terramate-ls` for running the tests, then choosing a higher version to avoid having this issue again too soon.