### PR TITLE
Add autocomplete for bundles .tm.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install the [Terramate Extension for VSCode](https://marketplace.visualstudio.co
 
 ### Step 3: Start Coding
 
-Open any folder containing Terramate files. Files with `.tm`, `.tm.hcl`, or `.tmgen` extensions will automatically activate the extension with full syntax highlighting and language server features.
+Open any folder containing Terramate files. Files with `.tm`, `.tm.hcl`, `.tmgen`, or `.tm.yml` extensions will automatically activate the extension with full syntax highlighting and language server features.
 
 ## Features
 
@@ -31,7 +31,8 @@ Open any folder containing Terramate files. Files with `.tm`, `.tm.hcl`, or `.tm
 
 Full syntax highlighting for all Terramate language constructs:
 - **Core blocks**: `terramate`, `stack`, `globals`, `generate_hcl`, `generate_file`, `assert`, `output`, `script`, `vendor`, `sharing_backend`, and more
-- **Pro blocks**: `define bundle`, `define component`, `scaffolding`  
+- **Pro blocks**: `define bundle`, `define component`, `scaffolding`
+- **YAML files**: Bundle instance files (`.tm.yml`) with JSON Schema-based autocomplete  
 
 ### Language Server Integration
 
@@ -44,6 +45,46 @@ When `terramate-ls` is installed, you get:
 - ✅ **Diagnostics** - Error and warning reporting
 
 **Bundle/Component Support**: Depends on your `terramate-ls` version. Language servers built from repositories with Pro features include full bundle and component validation.
+
+### Bundle Instance Support
+
+Bundle instances can be written in either YAML (`.tm.yml`) or HCL (`.tm.hcl`) format. Autocomplete support differs between formats:
+
+#### YAML Format (`.tm.yml`)
+
+The extension provides JSON Schema-based autocomplete and validation for bundle instance YAML files:
+
+- ✅ **Structure autocomplete** - Autocomplete for `apiVersion`, `kind`, `metadata`, `spec` fields
+- ✅ **Field validation** - Validates required fields and data types
+- ✅ **Input support** - Supports bundle input definitions in the `spec.inputs` section
+
+**Note**: For full autocomplete support, VS Code's built-in YAML support or the [Red Hat YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) is recommended.
+
+#### HCL Format (`.tm.hcl`)
+
+Bundle instances in HCL format use the `bundle` block syntax:
+
+```hcl
+bundle "my-bundle" {
+  source = "/bundles/example.com/my-bundle/v1"
+  inputs {
+    input_name = value
+  }
+}
+```
+
+**Autocomplete for HCL bundle instances**:
+- ✅ **Language server support** - Autocomplete comes from `terramate-catalyst-ls` via LSP
+- ✅ **Input name completion** - When typing inside `inputs { }` block, the language server provides completion for available input names based on the bundle definition
+- ✅ **Type validation** - Input values are validated against bundle input type definitions
+- ✅ **Hover documentation** - Input descriptions appear on hover
+
+**Requirements**:
+- Language server (`terramate-catalyst-ls`) must support LSP completion for bundle inputs
+- Bundle source must be resolvable to load input definitions
+- Bundle definition must exist at the specified `source` path
+
+**Note**: Unlike YAML which uses static JSON Schema, HCL autocomplete is dynamic and provided entirely by the language server. If autocomplete doesn't work, ensure you're using a language server version that supports bundle completion.
 
 ## Configuration
 
@@ -98,10 +139,13 @@ If you have `*.hcl` files associated with another extension (e.g., Terraform), y
   "files.associations": {
     "*.tm.hcl": "terramate",
     "*.tm": "terramate",
-    "*.tmgen": "terramate"
+    "*.tmgen": "terramate",
+    "*.tm.yml": "yaml"
   }
 }
 ```
+
+**Note**: `.tm.yml` files are automatically associated with YAML language for autocomplete support.
 
 ## Troubleshooting
 
@@ -129,7 +173,42 @@ If you have `*.hcl` files associated with another extension (e.g., Terraform), y
 
 1. Check the file is recognized as Terramate (bottom right of VSCode)
 2. Try reloading VSCode
-3. Check file extension is `.tm` or `.tm.hcl`
+3. Check file extension is `.tm`, `.tm.hcl`, `.tmgen`, or `.tm.yml`
+
+### YAML Autocomplete Not Working
+
+1. Ensure you have VS Code's built-in YAML support or install the [Red Hat YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+2. Verify the file extension is `.tm.yml`
+3. Check that the file follows the bundle instance schema structure
+4. Try reloading VS Code window (Cmd/Ctrl+Shift+P → "Reload Window")
+
+### Bundle Autocomplete Not Working (HCL Format)
+
+1. **Verify language server is running**:
+   - Check Output panel → "Terramate" channel
+   - Ensure `terramate-catalyst-ls` is detected and started
+
+2. **Check language server version**:
+   - Bundle input completion requires a language server that supports LSP completion
+   - Verify you're using `terramate-catalyst-ls` (not just `terramate-ls`)
+
+3. **Verify bundle source is resolvable**:
+   - Ensure the bundle definition exists at the path specified in `source`
+   - Check that bundle definition includes `input` blocks
+
+4. **Check bundle definition**:
+   - Bundle must have `define bundle` with `input` blocks defined
+   - Input definitions should include `type` and `description` for best autocomplete experience
+
+5. **Enable LSP trace** (for debugging):
+   ```json
+   {
+     "terramate.languageServer.trace.server": "verbose"
+   }
+   ```
+   Check Output panel → "Terramate Language Server Trace" for completion requests
+
+**Note**: If autocomplete still doesn't work, the language server may need enhancement to support bundle input completion. This would require changes to the `terramate-catalyst-ls` codebase.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,16 @@
 					"tm"
 				],
 				"configuration": "./language-configuration.json"
+			},
+			{
+				"id": "yaml",
+				"extensions": [
+					".tm.yml"
+				],
+				"aliases": [
+					"Terramate YAML",
+					"tm-yaml"
+				]
 			}
 		],
 		"grammars": [
@@ -52,6 +62,12 @@
 				"language": "terramate",
 				"scopeName": "source.tm",
 				"path": "./syntaxes/terramate.tmLanguage.json"
+			}
+		],
+		"yamlValidation": [
+			{
+				"fileMatch": "*.tm.yml",
+				"url": "./schemas/bundle-instance.schema.json"
 			}
 		],
 		"configuration": [

--- a/schemas/bundle-instance.schema.json
+++ b/schemas/bundle-instance.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Terramate Bundle Instance",
+  "description": "Schema for Terramate Catalyst bundle instance YAML files",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "terramate.io/cli/v1",
+      "description": "API version for Terramate Catalyst bundle instances"
+    },
+    "kind": {
+      "type": "string",
+      "const": "BundleInstance",
+      "description": "Resource kind"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Bundle instance name (lowercase alphanumeric, dashes, underscores)",
+          "pattern": "^[a-z][a-z0-9_-]*[a-z0-9]$",
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "uuid": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Optional UUID for the bundle instance"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": ["source"],
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Bundle source path (e.g., /bundles/example.com/my-bundle/v1)"
+        },
+        "inputs": {
+          "type": "object",
+          "description": "Bundle input values. Input names and types are defined by the bundle definition.",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/testFixture/bundles/bundle-instance.tm.hcl
+++ b/testFixture/bundles/bundle-instance.tm.hcl
@@ -1,0 +1,14 @@
+# Example bundle instance in HCL format
+# This file tests syntax highlighting and autocomplete for bundle instantiation blocks
+
+bundle "test-bundle-instance" {
+  source = "/bundles/example.com/test-bundle/v1"
+  uuid   = "79a83f2e-dbc0-429e-80e0-d0c395f0f605"
+  
+  inputs {
+    env      = "dev"
+    name     = "test-instance"
+    vpc_cidr = "10.0.0.0/16"
+    tags     = {}
+  }
+}

--- a/testFixture/bundles/bundle-instance.tm.yml
+++ b/testFixture/bundles/bundle-instance.tm.yml
@@ -1,0 +1,12 @@
+apiVersion: terramate.io/cli/v1
+kind: BundleInstance
+metadata:
+  name: test-bundle-instance
+  uuid: 79a83f2e-dbc0-429e-80e0-d0c395f0f605
+spec:
+  source: /bundles/example.com/test-bundle/v1
+  inputs:
+    env: dev
+    name: test-instance
+    vpc_cidr: 10.0.0.0/16
+    tags: {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mainly editor configuration and documentation changes; risk is limited to potentially incorrect schema/associations affecting YAML editing experience.
> 
> **Overview**
> Adds first-class support for bundle instance YAML files (`.tm.yml`) by associating them with the YAML language and wiring VS Code `yamlValidation` to a new `schemas/bundle-instance.schema.json` for autocomplete/validation.
> 
> Updates documentation to mention `.tm.yml` activation, file associations, and troubleshooting for YAML vs HCL bundle-instance autocomplete, and adds new bundle instance fixtures in both `.tm.hcl` and `.tm.yml` for testing/demo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e5f7ffa58e926d6ad382bf2803185b9b24e8dd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->